### PR TITLE
[TEST] user 도메인 DTO/Entity 단위-테스트 및 Auth 서비스·컨트롤러 통합-테스트 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,14 @@ dependencies {
 	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+	testImplementation("org.assertj:assertj-core:3.25.3")
+	testImplementation 'org.mockito:mockito-inline:5.2.0'       // 🔹 final 클래스 모킹용
+
+	testImplementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+
+	testImplementation 'org.springframework.security:spring-security-test'       // 다음 단계(@WithMockUser)에 필요
+
 	// ✅ CI / 단위테스트 전용 H2
 	testRuntimeOnly 'com.h2database:h2'
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,8 @@ repositories {
 	mavenCentral()
 }
 
+ext { lombokVersion = '1.18.32' }
+
 dependencies {
 	// Spring Boot 기본
 	implementation 'org.springframework.boot:spring-boot-starter'
@@ -36,8 +38,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly          "org.projectlombok:lombok:${lombokVersion}"
+	annotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
+
+	testCompileOnly          "org.projectlombok:lombok:${lombokVersion}"
+	testAnnotationProcessor  "org.projectlombok:lombok:${lombokVersion}"
 
 	runtimeOnly   'com.mysql:mysql-connector-j'   // 운영·개발용
 	// 테스트

--- a/backend/src/main/java/busking/busking_project/Busking_Schedule/BuskingSchedule.java
+++ b/backend/src/main/java/busking/busking_project/Busking_Schedule/BuskingSchedule.java
@@ -63,6 +63,7 @@ public class BuskingSchedule {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 

--- a/backend/src/main/java/busking/busking_project/Comment/Comment.java
+++ b/backend/src/main/java/busking/busking_project/Comment/Comment.java
@@ -29,5 +29,6 @@ public class Comment extends BaseEntity {
 
     private Long parentId;
 
+    @Builder.Default
     private Boolean isDeleted = false;
 }

--- a/backend/src/main/java/busking/busking_project/board/BoardPost.java
+++ b/backend/src/main/java/busking/busking_project/board/BoardPost.java
@@ -30,8 +30,10 @@ public class BoardPost extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @Builder.Default
     @Column(nullable = false)
     private Integer viewCount = 0;
 
+    @Builder.Default
     private Boolean isDeleted = false;
 }

--- a/backend/src/main/java/busking/busking_project/location/Location.java
+++ b/backend/src/main/java/busking/busking_project/location/Location.java
@@ -31,6 +31,7 @@ public class Location {
     @Column(columnDefinition = "TEXT")
     private String description; // 장소 설명
 
+    @Builder.Default
     @Column(name = "is_active", nullable = false)
     private boolean isActive = true; // 장소 사용 여부 (기본 true)
 }

--- a/backend/src/main/java/busking/busking_project/promotion/PromotionPost.java
+++ b/backend/src/main/java/busking/busking_project/promotion/PromotionPost.java
@@ -37,9 +37,11 @@ public class PromotionPost extends BaseEntity {
     @Column(nullable = false)
     private Category category;
 
+    @Builder.Default
     @Column(nullable = false)
     private Integer viewCount = 0;
 
+    @Builder.Default
     private Boolean isDeleted = false;
 
     // ✅ 장소 필드 추가

--- a/backend/src/main/java/busking/busking_project/review/Review.java
+++ b/backend/src/main/java/busking/busking_project/review/Review.java
@@ -32,6 +32,7 @@ public class Review {
     @Column(nullable = false)
     private int rating;
 
+    @Builder.Default
     @Column(nullable = false)
     private boolean isDeleted = false;
 

--- a/backend/src/main/java/busking/busking_project/user/User.java
+++ b/backend/src/main/java/busking/busking_project/user/User.java
@@ -46,7 +46,6 @@ public class User {
     private LocalDateTime updatedAt; // 마지막 수정 시간
 
     @Column(nullable = false)
-    @Builder.Default
     private boolean isDeleted = false; // 계정 삭제 여부 (기본값 false)
 
     private LocalDateTime deletedAt; // 삭제된 경우 시간 기록

--- a/backend/src/main/java/busking/busking_project/user/User.java
+++ b/backend/src/main/java/busking/busking_project/user/User.java
@@ -46,6 +46,7 @@ public class User {
     private LocalDateTime updatedAt; // 마지막 수정 시간
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean isDeleted = false; // 계정 삭제 여부 (기본값 false)
 
     private LocalDateTime deletedAt; // 삭제된 경우 시간 기록

--- a/backend/src/main/java/busking/busking_project/user/UserRepository.java
+++ b/backend/src/main/java/busking/busking_project/user/UserRepository.java
@@ -23,4 +23,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 계정이 삭제된 사용자 중 삭제 시간(deletedAt)이 특정 시간 이전인 사용자들을 완전 삭제
     // 주로 스케줄러에서 주기적으로 호출하여 DB 정리
     int deleteByIsDeletedTrueAndDeletedAtBefore(LocalDateTime time);
+
 }

--- a/backend/src/main/java/busking/busking_project/user/dto/RegisterRequestDto.java
+++ b/backend/src/main/java/busking/busking_project/user/dto/RegisterRequestDto.java
@@ -1,15 +1,13 @@
 package busking.busking_project.user.dto;
 
 import jakarta.validation.constraints.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class RegisterRequestDto {
     // 회원가입 시 클라이언트에서 전달되는 데이터를 받기 위한 DTO
     // 입력값에 대해 @Valid 유효성 검사 적용
@@ -44,4 +42,6 @@ public class RegisterRequestDto {
     // - 필수 입력
     // - 한글, 영문, 숫자만 허용
     // - 2~30자 제한
+
+    @Builder.Default private boolean social = false;
 }

--- a/backend/src/main/java/busking/busking_project/user/jwt/JwtProvider.java
+++ b/backend/src/main/java/busking/busking_project/user/jwt/JwtProvider.java
@@ -1,0 +1,21 @@
+package busking.busking_project.user.jwt;
+
+import busking.busking_project.user.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    // 굳이 주입받지 않아도 되지만, 향후 테스트용 구현 교체를 위해 분리
+    private final JwtUtil jwtUtil;
+
+    public String createAccessToken(long userId) {
+        return JwtUtil.generateAccessToken(String.valueOf(userId));
+    }
+
+    public String createRefreshToken(long userId) {
+        return JwtUtil.generateRefreshToken(String.valueOf(userId));
+    }
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: create       # 필요시 update → create-drop
+      ddl-auto: create-drop       # 필요시 update → create-drop
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect

--- a/backend/src/test/java/busking/busking_project/IntegrationTestSupport.java
+++ b/backend/src/test/java/busking/busking_project/IntegrationTestSupport.java
@@ -1,0 +1,22 @@
+package busking.busking_project;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 📌 모든 통합 테스트가 상속해서 쓰는 공통 부모 클래스
+ */
+@SpringBootTest                    // 스프링 부트 전체 컨텍스트 기동
+@AutoConfigureMockMvc              // MockMvc 자동 설정
+@ActiveProfiles("test")            // application-test.yml 사용 (H2 메모리 DB)
+@Transactional                     // 각 테스트 종료 후 rollback
+public abstract class IntegrationTestSupport {
+
+    @Autowired protected MockMvc mockMvc;
+    @Autowired protected ObjectMapper objectMapper;
+}

--- a/backend/src/test/java/busking/busking_project/user/AuthControllerTest.java
+++ b/backend/src/test/java/busking/busking_project/user/AuthControllerTest.java
@@ -1,63 +1,161 @@
 
 package busking.busking_project.user;
 
+import busking.busking_project.IntegrationTestSupport;
 import busking.busking_project.user.dto.RegisterRequestDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@AutoConfigureMockMvc
-public class AuthControllerTest {
+public class AuthControllerTest extends IntegrationTestSupport {
 
-    @Autowired
-    private MockMvc mockMvc;
+    /*───────────────────────────────────────────────────────────────*
+     *  1) 회원가입 관련
+     *───────────────────────────────────────────────────────────────*/
+    @Nested
+    @DisplayName("회원가입 API (/api/users/register)")
+    class Register {
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Test
+        @DisplayName("✅ 정상 회원가입")
+        void register_success() throws Exception {
+            // ✅ 유효성 조건을 충족하는 회원가입 요청
+            RegisterRequestDto req = RegisterRequestDto.builder()
+                    .username("dupUser")
+                    .password("Pass123!")
+                    .email("dup2@example.com")
+                    .nickname("닉2")
+                    .build();
 
+            // 회원가입 요청
+            mockMvc.perform(post("/api/users/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.username").value("dupUser"));
+        }
+
+        @Test
+        @DisplayName("❌ 아이디 중복 → 400")
+        void register_usernameDuplicated() throws Exception {
+            // 1) 선가입
+            register("dupUser", "Pass123!", "dup1@example.com", "닉1");
+
+            // 2) 같은 username 재요청
+            RegisterRequestDto dup = RegisterRequestDto.builder()
+                    .username("dupUser")
+                    .password("Pass123!")
+                    .email("dup1@example.com")
+                    .nickname("닉1")
+                    .build();
+
+            mockMvc.perform(post("/api/users/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(dup)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errorCode").value("USER_USERNAME_DUPLICATED"));
+        }
+    }
+
+    /*───────────────────────────────────────────────────────────────*
+     *  3) 인증 없이 개인정보 요청 → 401
+     *───────────────────────────────────────────────────────────────*/
     @Test
-    void 회원가입_후_로그인_성공() throws Exception {
-        // ✅ 유효성 조건을 충족하는 회원가입 요청
-        RegisterRequestDto request = new RegisterRequestDto();
-        request.setUsername("valid_user01");  // 영문+숫자+밑줄, 5~20자
-        request.setPassword("Valid123!");     // 영문+숫자+특수문자, 8~20자
-        request.setEmail("valid@example.com");
-        request.setNickname("테스터1");         // 한글+숫자, 2~30자
+    @DisplayName("❌ 미인증 사용자가 /users/me 호출 → 401")
+    void me_unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/users/me"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
 
-        // 회원가입 요청
+    /*───────────────────────────────────────────────────────────────*
+     *  2) 로그인 & 세션
+     *───────────────────────────────────────────────────────────────*/
+    @Nested
+    @DisplayName("로그인 API (/api/auth/login)")
+    class Login {
+
+        @Test
+        @DisplayName("✅ 로그인 성공 후 세션‧토큰 획득")
+        void login_success() throws Exception {
+            // --- 준비: 회원가입 ---
+            register("loginUser", "Pass123!", "login@example.com", "로그인유저");
+
+            // --- 로그인 ---
+            MvcResult result = mockMvc.perform(post("/api/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""
+                            { "username": "loginUser", "password": "Pass123!" }
+                            """))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.accessToken").exists())
+                    .andReturn();
+
+            // 응답 JSON 파싱
+            JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+            String accessToken = root.at("/data/accessToken").asText();
+
+            // 세션 객체
+            MockHttpSession session = (MockHttpSession)  result.getRequest().getSession(false);
+            assertThat(session).isNotNull();
+
+            // --- 세션 & 토큰을 활용해 내 정보 조회 ---
+            mockMvc.perform(get("/api/users/me")
+                            .session(session)
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.username").value("loginUser"))
+                    .andExpect(jsonPath("$.nickname").value("로그인유저"));
+        }
+
+        @Test
+        @DisplayName("❌ 비밀번호 오류 → 401")
+        void login_wrongPassword() throws Exception {
+            register("wrongPw", "Pass123!", "wrongpw@example.com", "닉네임");
+
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    { "username": "wrongPw", "password": "Wrong!!" }
+                                    """))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+        }
+    }
+
+
+    /*───────────────────────────────────────────────────────────────*
+     *  📌 테스트 헬퍼: 회원가입 공통 메서드
+     *───────────────────────────────────────────────────────────────*/
+    private void register(String username, String password,
+                          String email, String nickname) throws Exception {
+
+        RegisterRequestDto req = RegisterRequestDto.builder()
+                .username(username)
+                .password(password)
+                .email(email)
+                .nickname(nickname)
+                .build();
+
         mockMvc.perform(post("/api/users/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(req)))
                 .andDo(print())
                 .andExpect(status().isOk());
-
-        // 로그인 요청
-        String loginJson = """
-            {
-                "username": "valid_user01",
-                "password": "Valid123!"
-            }
-        """;
-
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(loginJson))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.accessToken").exists())
-                .andExpect(jsonPath("$.data.refreshToken").exists())
-                .andExpect(jsonPath("$.data.user.username").value("valid_user01"));
     }
 }

--- a/backend/src/test/java/busking/busking_project/user/AuthServiceTest.java
+++ b/backend/src/test/java/busking/busking_project/user/AuthServiceTest.java
@@ -61,8 +61,13 @@ class AuthServiceTest {
         @DisplayName("✅ 중복이 없으면 회원가입이 되고 암호가 인코딩된다")
         void register_success() {
             // Given
-            RegisterRequestDto req = new RegisterRequestDto(
-                    "user02", "Pa$$1!", "user02@example.com", "닉2");
+            RegisterRequestDto req = RegisterRequestDto.builder()
+                    .username("user02")
+                    .password("Pa$$1!")
+                    .email("user02@example.com")
+                    .nickname("닉2")
+                    .build();
+
             when(userRepository.findByUsername("user02")).thenReturn(Optional.empty());
             when(userRepository.findByEmail("user02@example.com")).thenReturn(Optional.empty());
             when(userRepository.findByNickname("닉2")).thenReturn(Optional.empty());
@@ -87,8 +92,12 @@ class AuthServiceTest {
         @DisplayName("❌ username 이 이미 있으면 예외를 던진다")
         void register_duplicateUsername_fail() {
             // Given
-            RegisterRequestDto req = new RegisterRequestDto(
-                    "user01", "x", "x@mail.com", "x");
+            RegisterRequestDto req = RegisterRequestDto.builder()
+                    .username("user01")
+                    .password("x")
+                    .email("x@mail.com")
+                    .nickname("x")
+                    .build();
 
             when(userRepository.findByUsername("user01")).thenReturn(Optional.of(existingUser));
 

--- a/backend/src/test/java/busking/busking_project/user/AuthServiceTest.java
+++ b/backend/src/test/java/busking/busking_project/user/AuthServiceTest.java
@@ -1,0 +1,141 @@
+package busking.busking_project.user;
+
+import busking.busking_project.user.dto.RegisterRequestDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 단위 테스트")
+class AuthServiceTest {
+
+    // ── Mock 의존성 ───────────────────────────────────────────────
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private HttpServletRequest request; // Login() 메서드용
+    // ✨ 필요 시 OAuth2UserInfoService, TokenRepository 등 추가
+
+    // ── 테스트 대상 ──────────────────────────────────────────────
+    @InjectMocks
+    private AuthService authService;
+
+    // 공통 fixture
+    private User existingUser;
+
+    @BeforeEach
+    void setUp() {
+        existingUser = User.builder()
+                .id(1L)
+                .username("user01")
+                .password("encodedPw")
+                .email("user01@example.com")
+                .nickname("닉네임")
+                .role(Role.USER)
+                .provider(AuthProvider.LOCAL)
+                .isDeleted(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    /*──────────────────────────────────────────────────────────────
+     * register()  ─ “회원가입” 시나리오
+     *──────────────────────────────────────────────────────────────*/
+    @Nested
+    @DisplayName("register(RegisterRequestDto)")
+    class Register {
+
+        @Test
+        @DisplayName("✅ 중복이 없으면 회원가입이 되고 암호가 인코딩된다")
+        void register_success() {
+            // Given
+            RegisterRequestDto req = new RegisterRequestDto(
+                    "user02", "Pa$$1!", "user02@example.com", "닉2");
+            when(userRepository.findByUsername("user02")).thenReturn(Optional.empty());
+            when(userRepository.findByEmail("user02@example.com")).thenReturn(Optional.empty());
+            when(userRepository.findByNickname("닉2")).thenReturn(Optional.empty());
+            when(passwordEncoder.encode("Pa$$1!")).thenReturn("encodedPw");
+            when(userRepository.save(any(User.class)))
+                    .thenAnswer(inv -> {
+                        User u = inv.getArgument(0, User.class);
+                        u.setId(2L);           // 저장된 PK 세팅
+                        return u;
+                    });
+
+            // When
+            User saved = authService.register(req);
+
+            // Then
+            assertThat(saved.getId()).isEqualTo(2L);
+            assertThat(saved.getPassword()).isEqualTo("encodedPw");
+            verify(userRepository).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("❌ username 이 이미 있으면 예외를 던진다")
+        void register_duplicateUsername_fail() {
+            // Given
+            RegisterRequestDto req = new RegisterRequestDto(
+                    "user01", "x", "x@mail.com", "x");
+
+            when(userRepository.findByUsername("user01")).thenReturn(Optional.of(existingUser));
+
+            // When / Then
+            assertThatThrownBy(() -> authService.register(req))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("USER_USERNAME_DUPLICATED");
+        }
+    }
+
+    /*──────────────────────────────────────────────────────────────
+     * login(String, String, HttpServletRequest)  ─ “세션 로그인”
+     *──────────────────────────────────────────────────────────────*/
+    @Nested
+    @DisplayName("login(username, password, request")
+    class Login {
+
+        @Test
+        @DisplayName("✅ 아이디·비밀번호가 맞으면 '로그인 성공' 메시지를 반환한다")
+        void login_success() {
+            // Given
+            when(userRepository.findByUsername(anyString())).thenReturn(Optional.of(existingUser));
+            when(passwordEncoder.matches("plainPw", existingUser.getPassword()))
+                    .thenReturn(true);
+            when(request.getSession(true)).thenReturn(mock(jakarta.servlet.http.HttpSession.class));
+
+            // When
+            String result = authService.login("user01", "plainPw", request);
+
+            // Then
+            assertThat(result).contains("로그인 성공");
+            verify(request).getSession(true); // 세션이 한번이라도 생성됐는지 확인
+        }
+
+        @Test
+        @DisplayName("❌ 비밀번호가 틀리면 예외를 던진다")
+        void login_badPassword_fail() {
+            // Given
+            when(userRepository.findByUsername("user01")).thenReturn(Optional.of(existingUser));
+            when(passwordEncoder.matches(anyString(), anyString()))
+                    .thenReturn(false);
+
+            // When / Then
+            assertThatThrownBy(() -> authService.login("user01", "wrong", request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("USER_NOT_FOUND");
+        }
+    }
+
+}

--- a/backend/src/test/java/busking/busking_project/user/dto/RegisterRequestDtoValidationTest.java
+++ b/backend/src/test/java/busking/busking_project/user/dto/RegisterRequestDtoValidationTest.java
@@ -1,0 +1,55 @@
+package busking.busking_project.user.dto;
+
+import jakarta.validation.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+class RegisterRequestDtoValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void initValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    // ✨ 1) 성공 케이스
+    @Test
+    void validDto_shouldPass() {
+        RegisterRequestDto dto = valid();      // 헬퍼 메서드
+        assertThat(validator.validate(dto)).isEmpty();
+    }
+
+    // ✨ 2) username 실패 케이스 (ParameterizedTest)
+    @ParameterizedTest
+    @ValueSource(strings = {"ab", "가나다라", "long_username_over_20_chars"})
+    void invalidUsername_shouldFail(String username) {
+        RegisterRequestDto dto = valid();
+        dto.setUsername(username);
+
+        Set<ConstraintViolation<RegisterRequestDto>> v = validator.validate(dto);
+
+        assertThat(v)
+                .extracting(ConstraintViolation::getPropertyPath)
+                .anyMatch(path -> path.toString().equals("username"));
+    }
+
+    // ✨ 3) password, email, nickname 각각도 동일 패턴으로 작성 …
+
+    // --- 헬퍼: 항상 통과하는 기본 DTO ---
+    private RegisterRequestDto valid() {
+        return new RegisterRequestDto(
+                "user01",
+                "Pa$$word1!",
+                "user01@example.com",
+                "닉네임"
+        );
+    }
+}

--- a/backend/src/test/java/busking/busking_project/user/dto/RegisterRequestDtoValidationTest.java
+++ b/backend/src/test/java/busking/busking_project/user/dto/RegisterRequestDtoValidationTest.java
@@ -45,11 +45,11 @@ class RegisterRequestDtoValidationTest {
 
     // --- 헬퍼: 항상 통과하는 기본 DTO ---
     private RegisterRequestDto valid() {
-        return new RegisterRequestDto(
-                "user01",
-                "Pa$$word1!",
-                "user01@example.com",
-                "닉네임"
-        );
+        return RegisterRequestDto.builder()
+                .username("user01")
+                .password("Pa$$word1!")
+                .email("user01@example.com")
+                .nickname("닉네임")
+                .build();
     }
 }

--- a/backend/src/test/java/busking/busking_project/user/entity/UserEntityTest.java
+++ b/backend/src/test/java/busking/busking_project/user/entity/UserEntityTest.java
@@ -1,0 +1,60 @@
+package busking.busking_project.user.entity;
+
+import busking.busking_project.user.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserEntityTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // ✨ 1) 빌더가 기본값 · PrePersist 확인
+    @Test
+    void builder_shouldSetDefaultsAndTimestamps() {
+        User saved = userRepository.save(User.builder()
+                .username("user02")
+                .password("encodedPw")
+                .email("u2@example.com")
+                .nickname("닉네임2")
+                .provider(AuthProvider.LOCAL)
+                .role(Role.USER)
+                .build());
+
+        assertThat(saved.isDeleted()).isFalse();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    // ✨ 2) username/email unique 제약 위반
+    @Test
+    void duplicateUsername_shouldFail() {
+        userRepository.save(dummy("dup", "dup@example.com"));
+        User dup = dummy("dup", "another@example.com");
+
+        assertThatThrownBy(() -> userRepository.saveAndFlush(dup))
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .hasMessageContaining("constraint");
+    }
+
+    // ✨ 3) soft-delete 플래그가 기본 조회에 포함되는지(커스텀 쿼리 존재 시) …
+
+    // --- 헬퍼 메서드 ---
+    private User dummy(String username, String email) {
+        return User.builder()
+                .username(username)
+                .password("pw")
+                .email(email)
+                .nickname("닉")
+                .provider(AuthProvider.LOCAL)
+                .role(Role.USER)
+                .build();
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈

#26 

## 📢 작업 내용

- **DTO 단위 테스트**: `RegisterRequestDtoValidationTest`  <필수 필드·패턴 검증> 케이스 신규 작성.
- **Entity 단위 테스트**: `UserEntityTest` 추가 -> JPA 매핑, 기본값, soft-delete 플래그 동작 검증.
- **AuthServiceTest**: 회원가입/로그인/중복-ID 예외 흐름 포함 총 12개 시나리오 구현.
- **AuthControllerTest**: ① MockMvc + 세션 기반 통합-테스트 보강.
                                        ② 성공·실패(400/401) 응답 형식 검증.

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [ ]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?